### PR TITLE
feat(url): added custom url parser for vmess/vless/trojan/ss/ssr

### DIFF
--- a/int.go
+++ b/int.go
@@ -1,0 +1,44 @@
+package proxyclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type Int struct {
+	v int
+}
+
+func (i *Int) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.v)
+}
+
+func (i *Int) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as an integer directly
+	var valueInt int
+	if err := json.Unmarshal(data, &valueInt); err == nil {
+		*i = Int{v: valueInt}
+		return nil
+	}
+
+	// If that fails, try to unmarshal as a string
+	var valueStr string
+	if err := json.Unmarshal(data, &valueStr); err != nil {
+		return fmt.Errorf("value must be an integer or a string representation of an integer: %w", err)
+	}
+
+	// Convert the string to an integer
+	valueInt, err := strconv.Atoi(valueStr)
+	if err != nil {
+		return fmt.Errorf("failed to convert string to integer: %w", err)
+	}
+
+	*i = Int{v: valueInt}
+	return nil
+}
+
+// Add a getter method to retrieve the value
+func (i Int) Value() int {
+	return i.v
+}

--- a/proxy.go
+++ b/proxy.go
@@ -1,12 +1,9 @@
 package proxyclient
 
 import (
-	"encoding/json"
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 )
 
 type ProxyFunc func(*url.URL, *Options) (http.RoundTripper, error)
@@ -32,41 +29,4 @@ func GetFreePort() (int, error) {
 
 	addr := listener.Addr().(*net.TCPAddr)
 	return addr.Port, nil
-}
-
-type JsonInt struct {
-	v int
-}
-
-func (i *JsonInt) MarshalJSON() ([]byte, error) {
-	return json.Marshal(i.v)
-}
-
-func (i *JsonInt) UnmarshalJSON(data []byte) error {
-	// First try to unmarshal as an integer directly
-	var valueInt int
-	if err := json.Unmarshal(data, &valueInt); err == nil {
-		*i = JsonInt{v: valueInt}
-		return nil
-	}
-
-	// If that fails, try to unmarshal as a string
-	var valueStr string
-	if err := json.Unmarshal(data, &valueStr); err != nil {
-		return fmt.Errorf("value must be an integer or a string representation of an integer: %w", err)
-	}
-
-	// Convert the string to an integer
-	valueInt, err := strconv.Atoi(valueStr)
-	if err != nil {
-		return fmt.Errorf("failed to convert string to integer: %w", err)
-	}
-
-	*i = JsonInt{v: valueInt}
-	return nil
-}
-
-// Add a getter method to retrieve the value
-func (i JsonInt) Value() int {
-	return i.v
 }

--- a/ss/proxy_ss.go
+++ b/ss/proxy_ss.go
@@ -20,7 +20,7 @@ func init() {
 // ProxySsSocks5 creates a RoundTripper for Shadowsocks proxy
 func ProxySsSocks5(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	// Start Shadowsocks instance
-	port, err := StartSS(u.String(), 0)
+	port, err := StartSS(u, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -33,10 +33,11 @@ func ProxySsSocks5(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error
 
 func ProxySS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 
-	cfg, err := ParseSS(u.String())
+	su, err := ParseSSURL(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse Shadowsocks URL: %w", err)
 	}
+	cfg := su.cfg
 
 	m, err := createMethod(cfg.Method, cfg.Password)
 	if err != nil {

--- a/ss/ss.go
+++ b/ss/ss.go
@@ -2,12 +2,9 @@ package ss
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"net"
-	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -18,17 +15,6 @@ import (
 	"github.com/sagernet/sing-shadowsocks/shadowaead_2022"
 	md "github.com/sagernet/sing/common/metadata"
 )
-
-// Config holds Shadowsocks URL parameters
-type Config struct {
-	Server     string
-	Port       int
-	Method     string
-	Password   string
-	Plugin     string
-	PluginOpts string
-	Name       string
-}
 
 var (
 	mu      sync.Mutex
@@ -43,113 +29,6 @@ type Server struct {
 	Listener   net.Listener
 	SocksPort  int
 	Cancel     context.CancelFunc
-}
-
-// ParseSS parses a Shadowsocks URL
-func ParseSS(ssURL string) (*Config, error) {
-	// Remove the ss:// prefix
-	encodedPart := strings.TrimPrefix(ssURL, "ss://")
-
-	// Check if there's a tag/name part after #
-	var name string
-	if idx := strings.LastIndex(encodedPart, "#"); idx >= 0 {
-		name, _ = url.PathUnescape(encodedPart[idx+1:])
-		encodedPart = encodedPart[:idx]
-	}
-
-	// Check if the URL is using legacy format or SIP002
-	var method, password, server, port string
-	var plugin, pluginOpts string
-
-	if strings.Contains(encodedPart, "@") {
-		// SIP002 format
-		idx := strings.Index(encodedPart, "@")
-		userInfo := encodedPart[:idx]
-		serverPart := encodedPart[idx+1:]
-
-		// Decode user info which might be base64 encoded
-		if !strings.Contains(userInfo, ":") {
-			decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(userInfo)
-			if err != nil {
-				decoded, err = base64.StdEncoding.DecodeString(userInfo)
-				if err != nil {
-					return nil, fmt.Errorf("failed to decode user info: %w", err)
-				}
-			}
-			userInfo = string(decoded)
-		}
-
-		parts := strings.SplitN(userInfo, ":", 2)
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid user info format")
-		}
-		method = parts[0]
-		password = parts[1]
-
-		// Parse server address and plugin info
-		serverURL, err := url.Parse("scheme://" + serverPart)
-		if err != nil {
-			return nil, fmt.Errorf("invalid server address: %w", err)
-		}
-
-		server = serverURL.Hostname()
-		port = serverURL.Port()
-
-		// Parse plugin parameters
-		params := serverURL.Query()
-		plugin = params.Get("plugin")
-		if plugin != "" {
-			pluginParts := strings.SplitN(plugin, ";", 2)
-			if len(pluginParts) > 1 {
-				plugin = pluginParts[0]
-				pluginOpts = pluginParts[1]
-			}
-		}
-	} else {
-		// Legacy format - base64 encoded
-		decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(encodedPart)
-		if err != nil {
-			decoded, err = base64.StdEncoding.DecodeString(encodedPart)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode URL: %w", err)
-			}
-		}
-
-		text := string(decoded)
-		parts := strings.Split(text, "@")
-		if len(parts) != 2 {
-			return nil, fmt.Errorf("invalid URL format")
-		}
-
-		methodPwd := strings.SplitN(parts[0], ":", 2)
-		if len(methodPwd) != 2 {
-			return nil, fmt.Errorf("invalid method:password format")
-		}
-		method = methodPwd[0]
-		password = methodPwd[1]
-
-		serverParts := strings.SplitN(parts[1], ":", 2)
-		if len(serverParts) != 2 {
-			return nil, fmt.Errorf("invalid server:port format")
-		}
-		server = serverParts[0]
-		port = serverParts[1]
-	}
-
-	portInt, err := strconv.Atoi(port)
-	if err != nil {
-		return nil, fmt.Errorf("invalid port: %w", err)
-	}
-
-	return &Config{
-		Server:     server,
-		Port:       portInt,
-		Method:     method,
-		Password:   password,
-		Plugin:     plugin,
-		PluginOpts: pluginOpts,
-		Name:       name,
-	}, nil
 }
 
 // getServer looks up a running Shadowsocks server

--- a/ss/ss_url.go
+++ b/ss/ss_url.go
@@ -1,0 +1,164 @@
+package ss
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/cnlangzi/proxyclient"
+)
+
+func init() {
+	// Register the SS url parser
+	proxyclient.RegisterParser("ss", func(u *url.URL) (proxyclient.URL, error) {
+		return ParseSSURL(u)
+	})
+}
+
+// Config holds Shadowsocks URL parameters
+type Config struct {
+	Server     string
+	Port       int
+	Method     string
+	Password   string
+	Plugin     string
+	PluginOpts string
+	Name       string
+	raw        *url.URL `json:"-"`
+}
+
+type URL struct {
+	cfg *Config
+}
+
+func (v *URL) Raw() *url.URL {
+	return v.cfg.raw
+}
+
+func (v *URL) Title() string {
+	return "ssr://" + v.Host() + ":" + v.Port()
+}
+
+func (v *URL) Host() string {
+	return v.cfg.Server
+}
+
+func (v *URL) Port() string {
+	return strconv.Itoa(v.cfg.Port)
+}
+
+// ParseSSURL parses a Shadowsocks URL
+func ParseSSURL(u *url.URL) (*URL, error) {
+
+	ssURL := u.String()
+
+	// Remove the ss:// prefix
+	encodedPart := strings.TrimPrefix(ssURL, "ss://")
+
+	// Check if there's a tag/name part after #
+	var name string
+	if idx := strings.LastIndex(encodedPart, "#"); idx >= 0 {
+		name, _ = url.PathUnescape(encodedPart[idx+1:])
+		encodedPart = encodedPart[:idx]
+	}
+
+	// Check if the URL is using legacy format or SIP002
+	var method, password, server, port string
+	var plugin, pluginOpts string
+
+	if strings.Contains(encodedPart, "@") {
+		// SIP002 format
+		idx := strings.Index(encodedPart, "@")
+		userInfo := encodedPart[:idx]
+		serverPart := encodedPart[idx+1:]
+
+		// Decode user info which might be base64 encoded
+		if !strings.Contains(userInfo, ":") {
+			decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(userInfo)
+			if err != nil {
+				decoded, err = base64.StdEncoding.DecodeString(userInfo)
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode user info: %w", err)
+				}
+			}
+			userInfo = string(decoded)
+		}
+
+		parts := strings.SplitN(userInfo, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid user info format")
+		}
+		method = parts[0]
+		password = parts[1]
+
+		// Parse server address and plugin info
+		serverURL, err := url.Parse("scheme://" + serverPart)
+		if err != nil {
+			return nil, fmt.Errorf("invalid server address: %w", err)
+		}
+
+		server = serverURL.Hostname()
+		port = serverURL.Port()
+
+		// Parse plugin parameters
+		params := serverURL.Query()
+		plugin = params.Get("plugin")
+		if plugin != "" {
+			pluginParts := strings.SplitN(plugin, ";", 2)
+			if len(pluginParts) > 1 {
+				plugin = pluginParts[0]
+				pluginOpts = pluginParts[1]
+			}
+		}
+	} else {
+		// Legacy format - base64 encoded
+		decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(encodedPart)
+		if err != nil {
+			decoded, err = base64.StdEncoding.DecodeString(encodedPart)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode URL: %w", err)
+			}
+		}
+
+		text := string(decoded)
+		parts := strings.Split(text, "@")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid URL format")
+		}
+
+		methodPwd := strings.SplitN(parts[0], ":", 2)
+		if len(methodPwd) != 2 {
+			return nil, fmt.Errorf("invalid method:password format")
+		}
+		method = methodPwd[0]
+		password = methodPwd[1]
+
+		serverParts := strings.SplitN(parts[1], ":", 2)
+		if len(serverParts) != 2 {
+			return nil, fmt.Errorf("invalid server:port format")
+		}
+		server = serverParts[0]
+		port = serverParts[1]
+	}
+
+	portInt, err := strconv.Atoi(port)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port: %w", err)
+	}
+
+	cfg := &Config{
+		Server:     server,
+		Port:       portInt,
+		Method:     method,
+		Password:   password,
+		Plugin:     plugin,
+		PluginOpts: pluginOpts,
+		Name:       name,
+
+		raw: u,
+	}
+
+	return &URL{cfg: cfg}, nil
+}

--- a/url.go
+++ b/url.go
@@ -1,0 +1,48 @@
+package proxyclient
+
+import (
+	"net/url"
+)
+
+type FuncParser func(u *url.URL) (URL, error)
+
+var parsers = make(map[string]FuncParser)
+
+func RegisterParser(proto string, f FuncParser) {
+	parsers[proto] = f
+}
+
+type URL interface {
+	Raw() *url.URL
+	Host() string
+	Port() string
+}
+
+type stdURL struct {
+	url.URL
+}
+
+func (u *stdURL) Raw() *url.URL {
+	return &u.URL
+}
+
+func (u *stdURL) Host() string {
+	return u.URL.Host
+}
+func (u *stdURL) Port() string {
+	return u.URL.Port()
+}
+
+func ParseURL(u string) (URL, error) {
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		return nil, err
+	}
+
+	parser, ok := parsers[parsedURL.Scheme]
+	if ok {
+		return parser(parsedURL)
+	}
+
+	return &stdURL{*parsedURL}, nil
+}

--- a/url.go
+++ b/url.go
@@ -14,6 +14,7 @@ func RegisterParser(proto string, f FuncParser) {
 
 type URL interface {
 	Raw() *url.URL
+	Title() string
 	Host() string
 	Port() string
 }
@@ -24,6 +25,10 @@ type stdURL struct {
 
 func (u *stdURL) Raw() *url.URL {
 	return &u.URL
+}
+
+func (u *stdURL) Title() string {
+	return u.URL.String()
 }
 
 func (u *stdURL) Host() string {

--- a/xray/proxy_ssr.go
+++ b/xray/proxy_ssr.go
@@ -15,7 +15,7 @@ func init() {
 // ProxySSR creates a RoundTripper for SSR proxy
 func ProxySSR(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	// Start SSR client through Xray
-	_, port, err := StartSSR(u.String(), 0)
+	_, port, err := StartSSR(u, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start SSR proxy: %w", err)
 	}

--- a/xray/proxy_vless.go
+++ b/xray/proxy_vless.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 func ProxyVless(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
-	_, port, err := StartVless(u.String(), 0)
+	_, port, err := StartVless(u, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start VLESS proxy: %w", err)
 	}

--- a/xray/proxy_vmess.go
+++ b/xray/proxy_vmess.go
@@ -13,7 +13,7 @@ func init() {
 }
 
 func ProxyVmess(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
-	_, port, err := StartVmess(u.String(), 0)
+	_, port, err := StartVmess(u, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start VMess proxy: %w", err)
 	}

--- a/xray/ssr_url.go
+++ b/xray/ssr_url.go
@@ -1,0 +1,153 @@
+package xray
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/cnlangzi/proxyclient"
+)
+
+func init() {
+	// Register the SSR url parser
+	proxyclient.RegisterParser("ssr", func(u *url.URL) (proxyclient.URL, error) {
+		return ParseSSRURL(u)
+	})
+}
+
+// SSRConfig stores ShadowsocksR URL parameters
+type SSRConfig struct {
+	Server        string
+	Port          int
+	Method        string
+	Password      string
+	Protocol      string
+	ProtocolParam string
+	Obfs          string
+	ObfsParam     string
+	Name          string
+
+	raw *url.URL `json:"-"`
+}
+
+type SSRURL struct {
+	cfg *SSRConfig
+}
+
+func (v *SSRURL) Raw() *url.URL {
+	return v.cfg.raw
+}
+
+func (v *SSRURL) Title() string {
+	return "ssr://" + v.Host() + ":" + v.Port()
+}
+
+func (v *SSRURL) Host() string {
+	return v.cfg.Server
+}
+
+func (v *SSRURL) Port() string {
+	return strconv.Itoa(v.cfg.Port)
+}
+
+func ParseSSRURL(u *url.URL) (*SSRURL, error) {
+
+	ssrURL := u.String()
+	// Remove ssr:// prefix
+	ssrURL = strings.TrimPrefix(ssrURL, "ssr://")
+
+	// Decode base64
+	decoded, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(ssrURL)
+	if err != nil {
+		// Try standard base64
+		decoded, err = base64.StdEncoding.DecodeString(ssrURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode SSR URL: %w", err)
+		}
+	}
+
+	text := string(decoded)
+
+	// Separate main part and parameter part
+	var mainPart, paramPart string
+	if idx := strings.Index(text, "/?"); idx >= 0 {
+		mainPart = text[:idx]
+		paramPart = text[idx+2:]
+	} else if idx := strings.Index(text, "?"); idx >= 0 {
+		mainPart = text[:idx]
+		paramPart = text[idx+1:]
+	} else {
+		mainPart = text
+	}
+
+	// Parse main part
+	parts := strings.Split(mainPart, ":")
+	if len(parts) < 6 {
+		return nil, fmt.Errorf("invalid SSR URL format")
+	}
+
+	serverPort, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("invalid port: %w", err)
+	}
+
+	// Decode password
+	password, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(parts[5])
+	if err != nil {
+		// Try standard base64
+		password, err = base64.StdEncoding.DecodeString(parts[5])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode password: %w", err)
+		}
+	}
+
+	cfg := &SSRConfig{
+		Server:   parts[0],
+		Port:     serverPort,
+		Protocol: parts[2],
+		Method:   parts[3],
+		Obfs:     parts[4],
+		Password: string(password),
+
+		raw: u,
+	}
+
+	// Parse parameter part
+	if paramPart != "" {
+		params := strings.Split(paramPart, "&")
+		for _, param := range params {
+			kv := strings.SplitN(param, "=", 2)
+			if len(kv) != 2 {
+				continue
+			}
+
+			key := kv[0]
+			value := kv[1]
+
+			decodedValue, err := base64.URLEncoding.WithPadding(base64.NoPadding).DecodeString(value)
+			if err != nil {
+				// Try standard base64
+				decodedValue, err = base64.StdEncoding.DecodeString(value)
+				if err != nil {
+					// Use original value
+					decodedValue = []byte(value)
+				}
+			}
+
+			switch key {
+			case "obfsparam":
+				cfg.ObfsParam = string(decodedValue)
+			case "protoparam":
+				cfg.ProtocolParam = string(decodedValue)
+			case "remarks":
+				cfg.Name = string(decodedValue)
+			}
+		}
+	}
+
+	return &SSRURL{
+		cfg: cfg,
+	}, nil
+}

--- a/xray/vless.go
+++ b/xray/vless.go
@@ -3,10 +3,7 @@ package xray
 import (
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/url"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/cnlangzi/proxyclient"
@@ -14,137 +11,14 @@ import (
 	_ "github.com/xtls/xray-core/main/distro/all"
 )
 
-// VlessConfig stores VLESS URL parameters
-type VlessConfig struct {
-	UUID          string
-	Address       string
-	Port          int
-	Encryption    string
-	Flow          string
-	Type          string
-	Security      string
-	Path          string
-	Host          string
-	SNI           string
-	ALPN          string
-	Fingerprint   string
-	PublicKey     string
-	ShortID       string
-	SpiderX       string
-	ServiceName   string
-	AllowInsecure bool // Controls whether to allow insecure TLS connections
-}
-
-// ParseVless parses VLESS URL
-// vless://uuid@host:port?encryption=none&type=tcp&security=tls&sni=example.com...
-func ParseVless(vlessURL string) (*VlessConfig, error) {
-	// Remove vless:// prefix
-	vlessURL = strings.TrimPrefix(vlessURL, "vless://")
-
-	// Parse as standard URL
-	u, err := url.Parse("vless://" + vlessURL)
-	if err != nil {
-		return nil, fmt.Errorf("invalid VLESS URL: %w", err)
-	}
-
-	// Extract user information
-	if u.User == nil {
-		return nil, fmt.Errorf("missing user info in VLESS URL")
-	}
-	uuid := u.User.Username()
-
-	// Extract host and port
-	host, portStr, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		return nil, fmt.Errorf("invalid host:port in VLESS URL: %w", err)
-	}
-
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		return nil, fmt.Errorf("invalid port in VLESS URL: %w", err)
-	}
-
-	// Create configuration
-	config := &VlessConfig{
-		UUID:          uuid,
-		Address:       host,
-		Port:          port,
-		Encryption:    "none", // VLESS default encryption is none
-		Type:          "tcp",  // Default transport type
-		AllowInsecure: true,
-	}
-
-	// Parse query parameters
-	query := u.Query()
-
-	if v := query.Get("encryption"); v != "" {
-		config.Encryption = v
-	}
-
-	if v := query.Get("flow"); v != "" {
-		config.Flow = v
-	}
-
-	if v := query.Get("type"); v != "" {
-		config.Type = v
-		// XHTTP as explicitly supported type, but not auto-converted
-	}
-
-	if v := query.Get("security"); v != "" {
-		config.Security = v
-	}
-
-	if v := query.Get("path"); v != "" {
-		config.Path = v
-	}
-
-	if v := query.Get("host"); v != "" {
-		config.Host = v
-	}
-
-	if v := query.Get("sni"); v != "" {
-		config.SNI = v
-	} else if config.Host != "" {
-		config.SNI = config.Host
-	}
-
-	if v := query.Get("alpn"); v != "" {
-		config.ALPN = v
-	}
-
-	if v := query.Get("fp"); v != "" {
-		config.Fingerprint = v
-	}
-
-	if v := query.Get("pbk"); v != "" {
-		config.PublicKey = v
-	}
-
-	if v := query.Get("sid"); v != "" {
-		config.ShortID = v
-	}
-
-	if v := query.Get("spx"); v != "" {
-		config.SpiderX = v
-	}
-
-	if v := query.Get("serviceName"); v != "" {
-		config.ServiceName = v
-	}
-
-	if v := query.Get("allowInsecure"); v != "" {
-		if strings.ToLower(v) == "false" || v == "0" {
-			config.AllowInsecure = false
-		}
-	}
-
-	return config, nil
+func init() {
+	proxyclient.RegisterProxy("vless", ProxyVless)
 }
 
 // VlessToXRay converts VLESS URL to Xray JSON configuration
 func VlessToXRay(vlessURL string, port int) ([]byte, int, error) {
 	// Parse VLESS URL
-	vless, err := ParseVless(vlessURL)
+	vless, err := ParseVlessURL(vlessURL)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -157,17 +31,19 @@ func VlessToXRay(vlessURL string, port int) ([]byte, int, error) {
 		}
 	}
 
+	cfg := vless.cfg
+
 	// Create VLESS outbound configuration
 	vlessSettings := map[string]interface{}{
 		"vnext": []map[string]interface{}{
 			{
-				"address": vless.Address,
-				"port":    vless.Port,
+				"address": cfg.Address,
+				"port":    cfg.Port,
 				"users": []map[string]interface{}{
 					{
-						"id":         vless.UUID,
-						"flow":       vless.Flow,
-						"encryption": vless.Encryption,
+						"id":         cfg.UUID,
+						"flow":       cfg.Flow,
+						"encryption": cfg.Encryption,
 						"level":      0,
 					},
 				},
@@ -177,87 +53,87 @@ func VlessToXRay(vlessURL string, port int) ([]byte, int, error) {
 
 	// Create stream settings
 	streamSettings := &StreamSettings{
-		Network:  vless.Type,
-		Security: vless.Security,
+		Network:  cfg.Type,
+		Security: cfg.Security,
 	}
 
 	// Configure TLS - update this section
-	if vless.Security == "tls" {
+	if cfg.Security == "tls" {
 		streamSettings.TLSSettings = &TLSSettings{
-			ServerName:    vless.SNI,
-			AllowInsecure: vless.AllowInsecure, // Use the value read from configuration
+			ServerName:    cfg.SNI,
+			AllowInsecure: cfg.AllowInsecure, // Use the value read from configuration
 		}
 
-		if vless.Fingerprint != "" {
-			streamSettings.TLSSettings.Fingerprint = vless.Fingerprint
+		if cfg.Fingerprint != "" {
+			streamSettings.TLSSettings.Fingerprint = cfg.Fingerprint
 		}
 
-		if vless.ALPN != "" {
-			streamSettings.TLSSettings.ALPN = strings.Split(vless.ALPN, ",")
+		if cfg.ALPN != "" {
+			streamSettings.TLSSettings.ALPN = strings.Split(cfg.ALPN, ",")
 		}
 	}
 
 	// Configure XTLS - update this section
-	if vless.Security == "xtls" {
+	if cfg.Security == "xtls" {
 		streamSettings.Security = "xtls"
 		streamSettings.XTLSSettings = &TLSSettings{
-			ServerName:    vless.SNI,
-			AllowInsecure: vless.AllowInsecure, // Use the value read from configuration
+			ServerName:    cfg.SNI,
+			AllowInsecure: cfg.AllowInsecure, // Use the value read from configuration
 		}
 
-		if vless.Fingerprint != "" {
-			streamSettings.XTLSSettings.Fingerprint = vless.Fingerprint
+		if cfg.Fingerprint != "" {
+			streamSettings.XTLSSettings.Fingerprint = cfg.Fingerprint
 		}
 
-		if vless.ALPN != "" {
-			streamSettings.XTLSSettings.ALPN = strings.Split(vless.ALPN, ",")
+		if cfg.ALPN != "" {
+			streamSettings.XTLSSettings.ALPN = strings.Split(cfg.ALPN, ",")
 		}
 	}
 
 	// Configure Reality
-	if vless.Security == "reality" {
+	if cfg.Security == "reality" {
 		streamSettings.Security = "reality"
 		streamSettings.RealitySettings = &RealitySettings{
-			ServerName:  vless.SNI,
-			Fingerprint: vless.Fingerprint,
-			PublicKey:   vless.PublicKey,
-			ShortID:     vless.ShortID,
-			SpiderX:     vless.SpiderX,
+			ServerName:  cfg.SNI,
+			Fingerprint: cfg.Fingerprint,
+			PublicKey:   cfg.PublicKey,
+			ShortID:     cfg.ShortID,
+			SpiderX:     cfg.SpiderX,
 		}
 	}
 
 	// Configure based on transport type
-	switch vless.Type {
+	switch cfg.Type {
 	case "ws":
 		streamSettings.WSSettings = &WSSettings{
-			Path: vless.Path,
-			Host: vless.Host, // Use independent Host field instead of headers
+			Path: cfg.Path,
+			Host: cfg.Host, // Use independent Host field instead of headers
 		}
 
 	case "xhttp": // Add direct support for XHTTP
 		streamSettings.Network = "xhttp"
 		streamSettings.XHTTPSettings = &XHTTPSettings{
-			Host:    vless.Host,
-			Path:    vless.Path,
+			Host:    cfg.Host,
+			Path:    cfg.Path,
 			Method:  "GET",
 			Version: "h2",
 		}
 
 		// Select HTTP version based on ALPN settings
-		if vless.ALPN != "" {
-			if strings.Contains(vless.ALPN, "h3") {
+		if cfg.ALPN != "" {
+			if strings.Contains(cfg.ALPN, "h3") {
 				streamSettings.XHTTPSettings.Version = "h3"
 			}
 		}
 	case "tcp":
-		if vless.Host != "" || vless.Path != "" {
+		if cfg.Host != "" || cfg.Path != "" {
 			streamSettings.TCPSettings = &TCPSettings{
 				Header: &Header{
 					Type: "http",
 					Request: map[string]interface{}{
-						"path": []string{vless.Path},
+						"path": []string{cfg.Path},
 						"headers": map[string]interface{}{
-							"Host": []string{vless.Host},
+							"Host": []string{cfg.Host},
 						},
 					},
 				},
@@ -265,15 +141,15 @@ func VlessToXRay(vlessURL string, port int) ([]byte, int, error) {
 		}
 	case "grpc":
 		streamSettings.GRPCSettings = &GRPCSettings{
-			ServiceName: vless.ServiceName,
+			ServiceName: cfg.ServiceName,
 			MultiMode:   false,
 		}
 	case "http":
 		streamSettings.HTTPSettings = &HTTPSettings{
-			Path: vless.Path,
+			Path: cfg.Path,
 		}
-		if vless.Host != "" {
-			streamSettings.HTTPSettings.Host = []string{vless.Host}
+		if cfg.Host != "" {
+			streamSettings.HTTPSettings.Host = []string{cfg.Host}
 		}
 	}
 

--- a/xray/vless_url.go
+++ b/xray/vless_url.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	// Register the VLESS parser
+	// Register the VLESS url parser
 	proxyclient.RegisterParser("vless", func(u *url.URL) (proxyclient.URL, error) {
 		return ParseVlessURL(u)
 	})
@@ -37,7 +37,7 @@ type VlessConfig struct {
 	ServiceName   string
 	AllowInsecure bool // Controls whether to allow insecure TLS connections
 
-	url *url.URL
+	raw *url.URL `json:"-"`
 }
 
 type VlessURL struct {
@@ -45,7 +45,11 @@ type VlessURL struct {
 }
 
 func (v *VlessURL) Raw() *url.URL {
-	return v.cfg.url
+	return v.cfg.raw
+}
+
+func (v *VlessURL) Title() string {
+	return "vless://" + v.Host() + ":" + v.Port()
 }
 
 func (v *VlessURL) Host() string {
@@ -84,7 +88,7 @@ func ParseVlessURL(u *url.URL) (*VlessURL, error) {
 		Encryption:    "none", // VLESS default encryption is none
 		Type:          "tcp",  // Default transport type
 		AllowInsecure: true,
-		url:           u,
+		raw:           u,
 	}
 
 	// Parse query parameters

--- a/xray/vless_url.go
+++ b/xray/vless_url.go
@@ -1,0 +1,157 @@
+package xray
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/cnlangzi/proxyclient"
+)
+
+func init() {
+	// Register the VLESS parser
+	proxyclient.RegisterParser("vless", func(u *url.URL) (proxyclient.URL, error) {
+		return ParseVlessURL(u)
+	})
+}
+
+// VlessConfig stores VLESS URL parameters
+type VlessConfig struct {
+	UUID          string
+	Address       string
+	Port          int
+	Encryption    string
+	Flow          string
+	Type          string
+	Security      string
+	Path          string
+	Host          string
+	SNI           string
+	ALPN          string
+	Fingerprint   string
+	PublicKey     string
+	ShortID       string
+	SpiderX       string
+	ServiceName   string
+	AllowInsecure bool // Controls whether to allow insecure TLS connections
+
+	url *url.URL
+}
+
+type VlessURL struct {
+	cfg *VlessConfig
+}
+
+func (v *VlessURL) Raw() *url.URL {
+	return v.cfg.url
+}
+
+func (v *VlessURL) Host() string {
+	return v.cfg.Address
+}
+
+func (v *VlessURL) Port() string {
+	return strconv.Itoa(v.cfg.Port)
+}
+
+// ParseVlessURL parses VLESS URL
+// vless://uuid@host:port?encryption=none&type=tcp&security=tls&sni=example.com...
+func ParseVlessURL(u *url.URL) (*VlessURL, error) {
+	// Extract user information
+	if u.User == nil {
+		return nil, fmt.Errorf("missing user info in VLESS URL")
+	}
+	uuid := u.User.Username()
+
+	// Extract host and port
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid host:port in VLESS URL: %w", err)
+	}
+
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port in VLESS URL: %w", err)
+	}
+
+	// Create configuration
+	cfg := &VlessConfig{
+		UUID:          uuid,
+		Address:       host,
+		Port:          port,
+		Encryption:    "none", // VLESS default encryption is none
+		Type:          "tcp",  // Default transport type
+		AllowInsecure: true,
+		url:           u,
+	}
+
+	// Parse query parameters
+	query := u.Query()
+
+	if v := query.Get("encryption"); v != "" {
+		cfg.Encryption = v
+	}
+
+	if v := query.Get("flow"); v != "" {
+		cfg.Flow = v
+	}
+
+	if v := query.Get("type"); v != "" {
+		cfg.Type = v
+		// XHTTP as explicitly supported type, but not auto-converted
+	}
+
+	if v := query.Get("security"); v != "" {
+		cfg.Security = v
+	}
+
+	if v := query.Get("path"); v != "" {
+		cfg.Path = v
+	}
+
+	if v := query.Get("host"); v != "" {
+		cfg.Host = v
+	}
+
+	if v := query.Get("sni"); v != "" {
+		cfg.SNI = v
+	} else if cfg.Host != "" {
+		cfg.SNI = cfg.Host
+	}
+
+	if v := query.Get("alpn"); v != "" {
+		cfg.ALPN = v
+	}
+
+	if v := query.Get("fp"); v != "" {
+		cfg.Fingerprint = v
+	}
+
+	if v := query.Get("pbk"); v != "" {
+		cfg.PublicKey = v
+	}
+
+	if v := query.Get("sid"); v != "" {
+		cfg.ShortID = v
+	}
+
+	if v := query.Get("spx"); v != "" {
+		cfg.SpiderX = v
+	}
+
+	if v := query.Get("serviceName"); v != "" {
+		cfg.ServiceName = v
+	}
+
+	if v := query.Get("allowInsecure"); v != "" {
+		if strings.ToLower(v) == "false" || v == "0" {
+			cfg.AllowInsecure = false
+		}
+	}
+
+	return &VlessURL{
+		cfg: cfg,
+	}, nil
+}

--- a/xray/vmess.go
+++ b/xray/vmess.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"runtime"
 	"strings"
 
@@ -12,60 +13,18 @@ import (
 	_ "github.com/xtls/xray-core/main/distro/all"
 )
 
-// VmessConfig stores VMess URL parameters
-type VmessConfig struct {
-	V             string          `json:"v"`
-	PS            string          `json:"ps"`               // Remarks
-	Add           string          `json:"add"`              // Address
-	Port          proxyclient.Int `json:"port"`             // Port
-	ID            string          `json:"id"`               // UUID
-	Aid           proxyclient.Int `json:"aid"`              // AlterID
-	Net           string          `json:"net"`              // Transport protocol
-	Type          string          `json:"type"`             // Camouflage type
-	Host          string          `json:"host"`             // Camouflage domain
-	Path          string          `json:"path"`             // WebSocket path
-	TLS           string          `json:"tls"`              // TLS
-	SNI           string          `json:"sni"`              // TLS SNI
-	Alpn          string          `json:"alpn"`             // ALPN
-	Flow          string          `json:"flow"`             // XTLS Flow
-	Fp            string          `json:"fp"`               // Fingerprint
-	PbK           string          `json:"pbk"`              // PublicKey (Reality)
-	Sid           string          `json:"sid"`              // ShortID (Reality)
-	SpX           string          `json:"spx"`              // SpiderX (Reality)
-	Security      string          `json:"security"`         // Encryption method
-	XHTTPVer      string          `json:"xver"`             // XHTTP version, "h2" or "h3"
-	AllowInsecure bool            `json:"skip_cert_verify"` // Controls whether to allow insecure TLS connections
-}
-
 // VmessToXRay converts VMess URL to Xray JSON configuration
-func VmessToXRay(vmessURL string, port int) ([]byte, int, error) {
-	// Remove vmess:// prefix
-	encoded := strings.TrimPrefix(vmessURL, "vmess://")
-
-	// Base64 decode
-	decoded, err := base64Decode(encoded)
-	if err != nil {
-		return nil, 0, fmt.Errorf("base64 decode failed: %w", err)
-	}
-
-	// Parse to VMessConfig
-	vmess := &VmessConfig{
-		AllowInsecure: true,
-	}
-
-	if err := json.Unmarshal(decoded, vmess); err != nil {
-		return nil, 0, fmt.Errorf("JSON parsing failed: %w", err)
-	}
-
-	// If vmess.Net is "xhttp", we should handle it properly
-	// This should typically be in the JSON processing part after base64 decoding
-
+func VmessToXRay(vmess *VmessConfig, port int) ([]byte, int, error) {
+	var err error
 	if port < 1 {
 		port, err = proxyclient.GetFreePort()
 		if err != nil {
 			return nil, 0, err
 		}
 	}
+
+	// If vmess.Net is "xhttp", we should handle it properly
+	// This should typically be in the JSON processing part after base64 decoding
 
 	// Generate complete Xray configuration
 	config := createCompleteVmessConfig(vmess, port)
@@ -343,15 +302,23 @@ func configureGRPC(ss *StreamSettings, vmess *VmessConfig) {
 }
 
 // StartVmess starts a VMess client
-func StartVmess(vmessURL string, port int) (*core.Instance, int, error) {
+func StartVmess(u *url.URL, port int) (*core.Instance, int, error) {
+
+	vmessURL := u.String()
+
 	// Check if already running
 	server := getServer(vmessURL)
 	if server != nil {
 		return server.Instance, server.SocksPort, nil
 	}
 
+	vu, err := ParseVmessURL(u)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	// Get JSON configuration
-	jsonConfig, port, err := VmessToXRay(vmessURL, port)
+	jsonConfig, port, err := VmessToXRay(vu.cfg, port)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/xray/vmess.go
+++ b/xray/vmess.go
@@ -14,27 +14,27 @@ import (
 
 // VmessConfig stores VMess URL parameters
 type VmessConfig struct {
-	V             string              `json:"v"`
-	PS            string              `json:"ps"`               // Remarks
-	Add           string              `json:"add"`              // Address
-	Port          proxyclient.JsonInt `json:"port"`             // Port
-	ID            string              `json:"id"`               // UUID
-	Aid           proxyclient.JsonInt `json:"aid"`              // AlterID
-	Net           string              `json:"net"`              // Transport protocol
-	Type          string              `json:"type"`             // Camouflage type
-	Host          string              `json:"host"`             // Camouflage domain
-	Path          string              `json:"path"`             // WebSocket path
-	TLS           string              `json:"tls"`              // TLS
-	SNI           string              `json:"sni"`              // TLS SNI
-	Alpn          string              `json:"alpn"`             // ALPN
-	Flow          string              `json:"flow"`             // XTLS Flow
-	Fp            string              `json:"fp"`               // Fingerprint
-	PbK           string              `json:"pbk"`              // PublicKey (Reality)
-	Sid           string              `json:"sid"`              // ShortID (Reality)
-	SpX           string              `json:"spx"`              // SpiderX (Reality)
-	Security      string              `json:"security"`         // Encryption method
-	XHTTPVer      string              `json:"xver"`             // XHTTP version, "h2" or "h3"
-	AllowInsecure bool                `json:"skip_cert_verify"` // Controls whether to allow insecure TLS connections
+	V             string          `json:"v"`
+	PS            string          `json:"ps"`               // Remarks
+	Add           string          `json:"add"`              // Address
+	Port          proxyclient.Int `json:"port"`             // Port
+	ID            string          `json:"id"`               // UUID
+	Aid           proxyclient.Int `json:"aid"`              // AlterID
+	Net           string          `json:"net"`              // Transport protocol
+	Type          string          `json:"type"`             // Camouflage type
+	Host          string          `json:"host"`             // Camouflage domain
+	Path          string          `json:"path"`             // WebSocket path
+	TLS           string          `json:"tls"`              // TLS
+	SNI           string          `json:"sni"`              // TLS SNI
+	Alpn          string          `json:"alpn"`             // ALPN
+	Flow          string          `json:"flow"`             // XTLS Flow
+	Fp            string          `json:"fp"`               // Fingerprint
+	PbK           string          `json:"pbk"`              // PublicKey (Reality)
+	Sid           string          `json:"sid"`              // ShortID (Reality)
+	SpX           string          `json:"spx"`              // SpiderX (Reality)
+	Security      string          `json:"security"`         // Encryption method
+	XHTTPVer      string          `json:"xver"`             // XHTTP version, "h2" or "h3"
+	AllowInsecure bool            `json:"skip_cert_verify"` // Controls whether to allow insecure TLS connections
 }
 
 // VmessToXRay converts VMess URL to Xray JSON configuration

--- a/xray/vmess_url.go
+++ b/xray/vmess_url.go
@@ -1,0 +1,94 @@
+package xray
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/cnlangzi/proxyclient"
+)
+
+func init() {
+	// Register the VMESS url parser
+	proxyclient.RegisterParser("vmess", func(u *url.URL) (proxyclient.URL, error) {
+		return ParseVmessURL(u)
+	})
+}
+
+// VmessConfig stores VMess URL parameters
+type VmessConfig struct {
+	V             string          `json:"v"`
+	PS            string          `json:"ps"`               // Remarks
+	Add           string          `json:"add"`              // Address
+	Port          proxyclient.Int `json:"port"`             // Port
+	ID            string          `json:"id"`               // UUID
+	Aid           proxyclient.Int `json:"aid"`              // AlterID
+	Net           string          `json:"net"`              // Transport protocol
+	Type          string          `json:"type"`             // Camouflage type
+	Host          string          `json:"host"`             // Camouflage domain
+	Path          string          `json:"path"`             // WebSocket path
+	TLS           string          `json:"tls"`              // TLS
+	SNI           string          `json:"sni"`              // TLS SNI
+	Alpn          string          `json:"alpn"`             // ALPN
+	Flow          string          `json:"flow"`             // XTLS Flow
+	Fp            string          `json:"fp"`               // Fingerprint
+	PbK           string          `json:"pbk"`              // PublicKey (Reality)
+	Sid           string          `json:"sid"`              // ShortID (Reality)
+	SpX           string          `json:"spx"`              // SpiderX (Reality)
+	Security      string          `json:"security"`         // Encryption method
+	XHTTPVer      string          `json:"xver"`             // XHTTP version, "h2" or "h3"
+	AllowInsecure bool            `json:"skip_cert_verify"` // Controls whether to allow insecure TLS connections
+
+	raw *url.URL `json:"-"`
+}
+
+type VmessURL struct {
+	cfg *VmessConfig
+}
+
+func (v *VmessURL) Raw() *url.URL {
+	return v.cfg.raw
+}
+
+func (v *VmessURL) Title() string {
+	return "vmess://" + v.Host() + ":" + v.Port()
+}
+
+func (v *VmessURL) Host() string {
+	return v.cfg.Add
+}
+
+func (v *VmessURL) Port() string {
+	return strconv.Itoa(v.cfg.Port.Value())
+}
+
+func ParseVmessURL(u *url.URL) (*VmessURL, error) {
+
+	vmessURL := u.String()
+
+	// Remove vmess:// prefix
+	encoded := strings.TrimPrefix(vmessURL, "vmess://")
+
+	// Base64 decode
+	decoded, err := base64Decode(encoded)
+	if err != nil {
+		return nil, fmt.Errorf("base64 decode failed: %w", err)
+	}
+
+	// Parse to VMessConfig
+	vmess := &VmessConfig{
+		AllowInsecure: true,
+	}
+
+	if err := json.Unmarshal(decoded, vmess); err != nil {
+		return nil, fmt.Errorf("JSON parsing failed: %w", err)
+	}
+
+	vmess.raw = u
+
+	return &VmessURL{
+		cfg: vmess,
+	}, nil
+}


### PR DESCRIPTION
## Added
- feat(url): added custom url parser for `vmess`,`vless`,`trojan`,`ss` and `ssr`

## Summary by Sourcery

Refactor and enhance URL parsing for multiple proxy protocols by introducing custom URL parsers for VLESS, VMess, SSR, and Shadowsocks

New Features:
- Added custom URL parsing mechanism for VLESS, VMess, SSR, and Shadowsocks protocols
- Introduced a generic URL parsing interface with protocol-specific implementations

Enhancements:
- Simplified proxy configuration parsing logic
- Improved type handling for URL parameters
- Centralized URL parsing with a registration mechanism

Chores:
- Removed duplicate parsing logic across different proxy protocol implementations
- Standardized URL parsing approach across different protocols