### PR TITLE
fix(url): fixed Host issue on stdURL

### DIFF
--- a/url.go
+++ b/url.go
@@ -1,6 +1,7 @@
 package proxyclient
 
 import (
+	"net"
 	"net/url"
 )
 
@@ -35,7 +36,8 @@ func (u *stdURL) Opaque() string {
 }
 
 func (u *stdURL) Host() string {
-	return u.URL.Host
+	h, _, _ := net.SplitHostPort(u.URL.Host)
+	return h
 }
 func (u *stdURL) Port() string {
 	return u.URL.Port()

--- a/url.go
+++ b/url.go
@@ -36,7 +36,10 @@ func (u *stdURL) Opaque() string {
 }
 
 func (u *stdURL) Host() string {
-	h, _, _ := net.SplitHostPort(u.URL.Host)
+	h, _, err := net.SplitHostPort(u.URL.Host)
+	if err != nil {
+		return u.URL.Host
+	}
 	return h
 }
 func (u *stdURL) Port() string {


### PR DESCRIPTION
## Fixed
- fix(url): fixed `Host` issue on `stdURL`

## Summary by Sourcery

Bug Fixes:
- Correctly extract the hostname from a URL, separating it from the port number