### PR TITLE
fix(ss): fix ss panic

### DIFF
--- a/ss/proxy_ss.go
+++ b/ss/proxy_ss.go
@@ -81,7 +81,7 @@ func DialSS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 }
 
 func dialSsConn(m shadowsocks.Method, c net.Conn, addr string) (conn net.Conn, err error) {
-	defer recover()
+	defer recover() // nolint: errcheck
 
 	destination := metadata.ParseSocksaddr(addr)
 	conn, err = m.DialConn(c, destination)

--- a/ss/proxy_ss.go
+++ b/ss/proxy_ss.go
@@ -18,8 +18,8 @@ func init() {
 	proxyclient.RegisterProxy("ss", ProxySS)
 }
 
-// ProxySsSocks5 creates a RoundTripper for Shadowsocks proxy
-func ProxySsSocks5(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
+// ProxySS creates a RoundTripper for Shadowsocks proxy
+func ProxySS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	// Start Shadowsocks instance
 	port, err := StartSS(u, 0)
 	if err != nil {
@@ -32,7 +32,7 @@ func ProxySsSocks5(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error
 	return proxyclient.ProxySocks5(proxyURL, o)
 }
 
-func ProxySS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
+func DialSS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 
 	su, err := ParseSSURL(u)
 	if err != nil {

--- a/ss/proxy_ss.go
+++ b/ss/proxy_ss.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"net/url"
@@ -47,6 +48,11 @@ func ProxySS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	tr := proxyclient.CreateTransport(o)
 
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Printf("ss: Error in DialContext: %v\n", err)
+			}
+		}()
 		serverAddr := net.JoinHostPort(cfg.Server, strconv.Itoa(cfg.Port))
 		conn, err := net.Dial("tcp", serverAddr)
 		if err != nil {

--- a/ss/proxy_ss.go
+++ b/ss/proxy_ss.go
@@ -50,7 +50,7 @@ func ProxySS(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		defer func() {
 			if err := recover(); err != nil {
-				log.Printf("ss: Error in DialContext: %v\n", err)
+				log.Printf("ss: painic in dial to %s by %s : %v\n", addr, su.Raw().String(), err)
 			}
 		}()
 		serverAddr := net.JoinHostPort(cfg.Server, strconv.Itoa(cfg.Port))

--- a/ss/proxy_ss.go
+++ b/ss/proxy_ss.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	proxyclient.RegisterProxy("ss", ProxySS)
+	proxyclient.RegisterProxy("ss", DialSS)
 }
 
 // ProxySS creates a RoundTripper for Shadowsocks proxy

--- a/ss/ss_url.go
+++ b/ss/ss_url.go
@@ -38,7 +38,7 @@ func (v *URL) Raw() *url.URL {
 }
 
 func (v *URL) Opaque() string {
-	return strings.TrimPrefix(v.Config.raw.String(), "")
+	return strings.TrimPrefix(v.Config.raw.String(), "ss://")
 }
 
 func (v *URL) Host() string {

--- a/xray/ssr_url.go
+++ b/xray/ssr_url.go
@@ -41,7 +41,7 @@ func (v *SSRURL) Raw() *url.URL {
 }
 
 func (v *SSRURL) Opaque() string {
-	return strings.TrimPrefix(v.Config.raw.String(), "")
+	return strings.TrimPrefix(v.Config.raw.String(), "ssr://")
 }
 
 func (v *SSRURL) Host() string {


### PR DESCRIPTION
## Fixed
- fix(ss): fixed panic issue on invalid ss url

## Summary by Sourcery

Fix panic issue in Shadowsocks proxy connection handling by adding error recovery and logging

Bug Fixes:
- Prevent panic when creating Shadowsocks connections by adding a recovery mechanism and error logging
- Fix URL parsing for Shadowsocks and SSR URLs by correctly trimming URL prefixes

Enhancements:
- Refactor Shadowsocks proxy connection method to improve error handling
- Add logging for connection failures to aid in debugging