### PR TITLE
feat(xray): use `DialXX` instead of `PorxyXX` in xray

### DIFF
--- a/xray/dial.go
+++ b/xray/dial.go
@@ -1,0 +1,49 @@
+package xray
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/cnlangzi/proxyclient"
+	xnet "github.com/xtls/xray-core/common/net"
+	"github.com/xtls/xray-core/core"
+)
+
+func dialContext(ctx context.Context, instance *core.Instance, network, addr string) (net.Conn, error) {
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+
+	// Convert port string to uint16
+	portNum, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port: %w", err)
+	}
+
+	// Create network type based on the network parameter
+	var netType xnet.Network
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		netType = xnet.Network_TCP
+	case "udp", "udp4", "udp6":
+		netType = xnet.Network_UDP
+	default:
+		return nil, fmt.Errorf("unsupported network: %s", network)
+	}
+
+	// Create the destination
+	dest := xnet.Destination{
+		Network: netType,
+		Address: xnet.ParseAddress(host),
+		Port:    xnet.Port(portNum),
+	}
+
+	return proxyclient.WithRecover(func() (net.Conn, error) {
+		return core.Dial(ctx, instance, dest)
+	})
+
+}

--- a/xray/proxy_ssr.go
+++ b/xray/proxy_ssr.go
@@ -1,7 +1,9 @@
 package xray
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -9,7 +11,7 @@ import (
 )
 
 func init() {
-	proxyclient.RegisterProxy("ssr", ProxySSR)
+	proxyclient.RegisterProxy("ssr", DialSSR)
 }
 
 // ProxySSR creates a RoundTripper for SSR proxy
@@ -17,10 +19,28 @@ func ProxySSR(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	// Start SSR client through Xray
 	_, port, err := StartSSR(u, 0)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start SSR proxy: %w", err)
+		return nil, fmt.Errorf("failed to start ssr proxy: %w", err)
 	}
 
 	// Use SOCKS5 proxy created by Xray
 	proxyURL, _ := url.Parse(fmt.Sprintf("socks5://127.0.0.1:%d", port))
 	return proxyclient.ProxySocks5(proxyURL, o)
+}
+
+// DialSSR creates a custom transport that dials directly to the v2ray server
+// instead of using a local SOCKS proxy.
+func DialSSR(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
+	instance, _, err := StartVmess(u, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start ssr proxy: %w", err)
+	}
+
+	// Create a transport that uses our custom dialer
+	tr := proxyclient.CreateTransport(o)
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialContext(ctx, instance, network, addr)
+	}
+	tr.Proxy = nil
+
+	return tr, nil
 }

--- a/xray/proxy_ssr.go
+++ b/xray/proxy_ssr.go
@@ -30,7 +30,7 @@ func ProxySSR(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 // DialSSR creates a custom transport that dials directly to the v2ray server
 // instead of using a local SOCKS proxy.
 func DialSSR(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
-	instance, _, err := StartVmess(u, 0)
+	instance, _, err := StartSSR(u, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start ssr proxy: %w", err)
 	}

--- a/xray/proxy_trojan.go
+++ b/xray/proxy_trojan.go
@@ -1,7 +1,9 @@
 package xray
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -9,7 +11,7 @@ import (
 )
 
 func init() {
-	proxyclient.RegisterProxy("trojan", ProxyTrojan)
+	proxyclient.RegisterProxy("trojan", DialTrojan)
 }
 
 // ProxyTrojan creates a RoundTripper for Trojan proxy
@@ -23,4 +25,22 @@ func ProxyTrojan(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) 
 	// Use SOCKS5 proxy created by Xray
 	proxyURL, _ := url.Parse(fmt.Sprintf("socks5://127.0.0.1:%d", port))
 	return proxyclient.ProxySocks5(proxyURL, o)
+}
+
+// DialTrojan creates a custom transport that dials directly to the v2ray server
+// instead of using a local SOCKS proxy.
+func DialTrojan(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
+	instance, _, err := StartVmess(u, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start Trojan proxy: %w", err)
+	}
+
+	// Create a transport that uses our custom dialer
+	tr := proxyclient.CreateTransport(o)
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialContext(ctx, instance, network, addr)
+	}
+	tr.Proxy = nil
+
+	return tr, nil
 }

--- a/xray/proxy_trojan.go
+++ b/xray/proxy_trojan.go
@@ -32,7 +32,7 @@ func ProxyTrojan(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) 
 func DialTrojan(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	instance, _, err := StartTrojan(u, 0)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start Trojan proxy: %w", err)
+		return nil, fmt.Errorf("failed to start trojan proxy: %w", err)
 	}
 
 	// Create a transport that uses our custom dialer

--- a/xray/proxy_trojan.go
+++ b/xray/proxy_trojan.go
@@ -30,7 +30,7 @@ func ProxyTrojan(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) 
 // DialTrojan creates a custom transport that dials directly to the v2ray server
 // instead of using a local SOCKS proxy.
 func DialTrojan(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
-	instance, _, err := StartVmess(u, 0)
+	instance, _, err := StartTrojan(u, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start Trojan proxy: %w", err)
 	}

--- a/xray/proxy_vless.go
+++ b/xray/proxy_vless.go
@@ -1,7 +1,9 @@
 package xray
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -9,15 +11,33 @@ import (
 )
 
 func init() {
-	proxyclient.RegisterProxy("vless", ProxyVless)
+	proxyclient.RegisterProxy("vless", DialVless)
 }
 
 func ProxyVless(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	_, port, err := StartVless(u, 0)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start VLESS proxy: %w", err)
+		return nil, fmt.Errorf("failed to start vless proxy: %w", err)
 	}
 
 	proxyURL, _ := url.Parse(fmt.Sprintf("socks5://127.0.0.1:%d", port))
 	return proxyclient.ProxySocks5(proxyURL, o)
+}
+
+// DialVless creates a custom transport that dials directly to the v2ray server
+// instead of using a local SOCKS proxy.
+func DialVless(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
+	instance, _, err := StartVless(u, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start vless proxy: %w", err)
+	}
+
+	// Create a transport that uses our custom dialer
+	tr := proxyclient.CreateTransport(o)
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialContext(ctx, instance, network, addr)
+	}
+	tr.Proxy = nil
+
+	return tr, nil
 }

--- a/xray/proxy_vmess.go
+++ b/xray/proxy_vmess.go
@@ -1,7 +1,9 @@
 package xray
 
 import (
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -9,15 +11,33 @@ import (
 )
 
 func init() {
-	proxyclient.RegisterProxy("vmess", ProxyVmess)
+	proxyclient.RegisterProxy("vmess", DialVmess)
 }
 
 func ProxyVmess(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
 	_, port, err := StartVmess(u, 0)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start VMess proxy: %w", err)
+		return nil, fmt.Errorf("failed to start vmess proxy: %w", err)
 	}
 
 	proxyURL, _ := url.Parse(fmt.Sprintf("socks5://127.0.0.1:%d", port))
 	return proxyclient.ProxySocks5(proxyURL, o)
+}
+
+// DialVmess creates a custom transport that dials directly to the v2ray server
+// instead of using a local SOCKS proxy.
+func DialVmess(u *url.URL, o *proxyclient.Options) (http.RoundTripper, error) {
+	instance, _, err := StartVmess(u, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to start vmess proxy: %w", err)
+	}
+
+	// Create a transport that uses our custom dialer
+	tr := proxyclient.CreateTransport(o)
+	tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return dialContext(ctx, instance, network, addr)
+	}
+	tr.Proxy = nil
+
+	return tr, nil
 }


### PR DESCRIPTION
## Added
- feat(xray): added `DialXX` to dial xray connection instead of forwarding request by local socks server

## Summary by Sourcery

Replace proxy methods with direct dialing methods for Xray proxy connections, improving network connectivity by eliminating the local SOCKS proxy intermediary.

New Features:
- Implement direct dialing mechanism for Xray proxy connections using `DialXX` methods instead of proxying through a local SOCKS server

Enhancements:
- Refactor proxy connection methods to use direct network dialing for SSR, VLESS, VMESS, and Trojan protocols
- Introduce a generic `dialContext` function to handle network connections across different proxy types