### PR TITLE
fix(vmess): fixed json issue on tls

### DIFF
--- a/bool.go
+++ b/bool.go
@@ -1,0 +1,41 @@
+package proxyclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Bool struct {
+	v bool
+}
+
+func (i *Bool) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.v)
+}
+
+func (i *Bool) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as an integer directly
+	var v bool
+	if err := json.Unmarshal(data, &v); err == nil {
+		*i = Bool{v: v}
+		return nil
+	}
+
+	// If that fails, try to unmarshal as a string
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("value must be an integer or a string representation of an integer: %w", err)
+	}
+
+	s = strings.ToLower(s)
+	v = s == "true" || s == "1" || s == "yes" || s == "on" || s == "y" || s == "t"
+
+	*i = Bool{v: v}
+	return nil
+}
+
+// Add a getter method to retrieve the value
+func (i Bool) Value() bool {
+	return i.v
+}

--- a/bool.go
+++ b/bool.go
@@ -25,7 +25,7 @@ func (i *Bool) UnmarshalJSON(data []byte) error {
 	// If that fails, try to unmarshal as a string
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("value must be an integer or a string representation of an integer: %w", err)
+		return fmt.Errorf("value must be a boolean or a string representation of a boolean: %w", err)
 	}
 
 	s = strings.ToLower(s)

--- a/string.go
+++ b/string.go
@@ -24,7 +24,7 @@ func (i *String) UnmarshalJSON(data []byte) error {
 	// If that fails, try to unmarshal as a string
 	var s any
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("value must be an integer or a string representation of an integer: %w", err)
+		return fmt.Errorf("value must be a string or a value that can be converted to a string: %w", err)
 	}
 
 	v = fmt.Sprint(s)

--- a/string.go
+++ b/string.go
@@ -1,0 +1,39 @@
+package proxyclient
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type String struct {
+	v string
+}
+
+func (i *String) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.v)
+}
+
+func (i *String) UnmarshalJSON(data []byte) error {
+	// First try to unmarshal as an integer directly
+	var v string
+	if err := json.Unmarshal(data, &v); err == nil {
+		*i = String{v: v}
+		return nil
+	}
+
+	// If that fails, try to unmarshal as a string
+	var s any
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("value must be an integer or a string representation of an integer: %w", err)
+	}
+
+	v = fmt.Sprint(s)
+
+	*i = String{v: v}
+	return nil
+}
+
+// Add a getter method to retrieve the value
+func (i String) Value() string {
+	return i.v
+}

--- a/xray/vmess.go
+++ b/xray/vmess.go
@@ -126,11 +126,13 @@ func getSecurityMethod(vmess *VmessConfig) string {
 func buildEnhancedStreamSettings(vmess *VmessConfig) *StreamSettings {
 	ss := &StreamSettings{
 		Network:  vmess.Net,
-		Security: vmess.TLS,
+		Security: vmess.TLS.Value(),
 	}
 
+	tls := vmess.TLS.Value()
+
 	// Configure TLS
-	if vmess.TLS == "tls" {
+	if tls == "tls" || tls == "true" {
 		ss.TLSSettings = &TLSSettings{
 			ServerName:    vmess.Host,
 			AllowInsecure: vmess.AllowInsecure, // Use the value read from configuration
@@ -150,7 +152,7 @@ func buildEnhancedStreamSettings(vmess *VmessConfig) *StreamSettings {
 	}
 
 	// Configure XTLS
-	if vmess.TLS == "xtls" {
+	if tls == "xtls" {
 		ss.Security = "xtls"
 		ss.XTLSSettings = &TLSSettings{
 			ServerName:    vmess.Host,
@@ -171,7 +173,7 @@ func buildEnhancedStreamSettings(vmess *VmessConfig) *StreamSettings {
 	}
 
 	// Configure Reality
-	if vmess.TLS == "reality" {
+	if tls == "reality" {
 		ss.Security = "reality"
 		ss.RealitySettings = &RealitySettings{
 			ServerName:  vmess.SNI,

--- a/xray/vmess_url.go
+++ b/xray/vmess_url.go
@@ -19,27 +19,27 @@ func init() {
 
 // VmessConfig stores VMess URL parameters
 type VmessConfig struct {
-	V             string          `json:"v"`
-	PS            string          `json:"ps"`               // Remarks
-	Add           string          `json:"add"`              // Address
-	Port          proxyclient.Int `json:"port"`             // Port
-	ID            string          `json:"id"`               // UUID
-	Aid           proxyclient.Int `json:"aid"`              // AlterID
-	Net           string          `json:"net"`              // Transport protocol
-	Type          string          `json:"type"`             // Camouflage type
-	Host          string          `json:"host"`             // Camouflage domain
-	Path          string          `json:"path"`             // WebSocket path
-	TLS           string          `json:"tls"`              // TLS
-	SNI           string          `json:"sni"`              // TLS SNI
-	Alpn          string          `json:"alpn"`             // ALPN
-	Flow          string          `json:"flow"`             // XTLS Flow
-	Fp            string          `json:"fp"`               // Fingerprint
-	PbK           string          `json:"pbk"`              // PublicKey (Reality)
-	Sid           string          `json:"sid"`              // ShortID (Reality)
-	SpX           string          `json:"spx"`              // SpiderX (Reality)
-	Security      string          `json:"security"`         // Encryption method
-	XHTTPVer      string          `json:"xver"`             // XHTTP version, "h2" or "h3"
-	AllowInsecure bool            `json:"skip_cert_verify"` // Controls whether to allow insecure TLS connections
+	V             proxyclient.Int    `json:"v"`
+	PS            string             `json:"ps"`               // Remarks
+	Add           string             `json:"add"`              // Address
+	Port          proxyclient.Int    `json:"port"`             // Port
+	ID            string             `json:"id"`               // UUID
+	Aid           proxyclient.Int    `json:"aid"`              // AlterID
+	Net           string             `json:"net"`              // Transport protocol
+	Type          string             `json:"type"`             // Camouflage type
+	Host          string             `json:"host"`             // Camouflage domain
+	Path          string             `json:"path"`             // WebSocket path
+	TLS           proxyclient.String `json:"tls"`              // TLS
+	SNI           string             `json:"sni"`              // TLS SNI
+	Alpn          string             `json:"alpn"`             // ALPN
+	Flow          string             `json:"flow"`             // XTLS Flow
+	Fp            string             `json:"fp"`               // Fingerprint
+	PbK           string             `json:"pbk"`              // PublicKey (Reality)
+	Sid           string             `json:"sid"`              // ShortID (Reality)
+	SpX           string             `json:"spx"`              // SpiderX (Reality)
+	Security      string             `json:"security"`         // Encryption method
+	XHTTPVer      string             `json:"xver"`             // XHTTP version, "h2" or "h3"
+	AllowInsecure bool               `json:"skip_cert_verify"` // Controls whether to allow insecure TLS connections
 
 	raw *url.URL `json:"-"`
 }

--- a/xray/vmess_url_test.go
+++ b/xray/vmess_url_test.go
@@ -1,0 +1,21 @@
+package xray
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVmessURL(t *testing.T) {
+	u, _ := url.Parse("vmess://ewogICJ2IjogMiwKICAicHMiOiAiVk1FU1Mt5pyq55+lPuW+t+WbvS1ORuino+mUgeW+t+WbveWcsOWMuumdnuiHquWItuWJpy1DaGF0R1BULVRpa1Rvay1Zb3VUdWJlLWRlMDEuc2gtY2xvdWRmbGFyZS5zYnM6MjA5NiIsCiAgImFkZCI6ICJkZTAxLnNoLWNsb3VkZmxhcmUuc2JzIiwKICAicG9ydCI6IDIwOTYsCiAgImlkIjogIjc1YTA4ODVmLTBjYTUtNDJhNC04NjUxLTM5MWNmODE5MzE1NCIsCiAgImFpZCI6IDAsCiAgInNjeSI6ICJhdXRvIiwKICAibmV0IjogIndzIiwKICAidHlwZSI6IG51bGwsCiAgImhvc3QiOiAiZGUwMS5zaC1jbG91ZGZsYXJlLnNicyIsCiAgInBhdGgiOiAiLyIsCiAgInRscyI6IHRydWUsCiAgInNuaSI6ICIiCn0=")
+
+	vmessURL, err := ParseVmessURL(u)
+	require.NoError(t, err)
+	require.Equal(t, "vmess", vmessURL.Protocol())
+
+	u, _ = url.Parse("vmess://eyJ2IjogIjIiLCAicHMiOiAiXHU1YzcxXHU0ZTFjXHU3NzAxXHU5NzUyXHU1YzliXHU1ZTAyIFx1ODA1NFx1OTAxYSIsICJhZGQiOiAidjQwLmhlZHVpYW4ubGluayIsICJwb3J0IjogIjMwODQwIiwgInR5cGUiOiAibm9uZSIsICJpZCI6ICJjYmIzZjg3Ny1kMWZiLTM0NGMtODdhOS1kMTUzYmZmZDU0ODQiLCAiYWlkIjogIjAiLCAibmV0IjogIndzIiwgInBhdGgiOiAiL2luZGV4IiwgImhvc3QiOiAiYXBpMTAwLWNvcmUtcXVpYy1sZi5hbWVtdi5jb20iLCAidGxzIjogIiJ9")
+	vmessURL, err = ParseVmessURL(u)
+	require.NoError(t, err)
+	require.Equal(t, "vmess", vmessURL.Protocol())
+}


### PR DESCRIPTION
## Fixed
- fix(vmess): fixed json issue on `tls`

## Summary by Sourcery

Improve JSON parsing and handling for VMess configuration, particularly for TLS and boolean fields

Bug Fixes:
- Fixed JSON parsing for TLS configuration to handle various input formats (string, boolean, etc.)

Enhancements:
- Added more flexible JSON unmarshaling for TLS and boolean fields in VMess configuration
- Introduced custom String and Bool types to handle diverse JSON input formats

Tests:
- Added test cases for VMess URL parsing to validate different configuration scenarios