### PR TITLE
fix(socks): reset tr.Proxy

### DIFF
--- a/proxy_socks.go
+++ b/proxy_socks.go
@@ -69,6 +69,8 @@ func ProxySocks4(u *url.URL, o *Options) (http.RoundTripper, error) {
 		return dialTLSContext(ctx, tr.DialContext, network, addr, tr.TLSClientConfig)
 	}
 
+	tr.Proxy = nil
+
 	return tr, nil
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Reset `tr.Proxy` to `nil` in `ProxySocks4` to prevent potential interference from environment proxies.