### PR TITLE
fix(xray): removed unused xray packages

### DIFF
--- a/xray/xray.go
+++ b/xray/xray.go
@@ -12,30 +12,21 @@ import (
 	_ "github.com/xtls/xray-core/app/proxyman/inbound"
 	_ "github.com/xtls/xray-core/app/proxyman/outbound"
 
-	// Default commander and all its services. This is an optional feature.
-	_ "github.com/xtls/xray-core/app/commander"
-	_ "github.com/xtls/xray-core/app/log/command"
-	_ "github.com/xtls/xray-core/app/proxyman/command"
-	_ "github.com/xtls/xray-core/app/stats/command"
-
-	// Developer preview services
-	_ "github.com/xtls/xray-core/app/observatory/command"
-
 	// Other optional features.
 	_ "github.com/xtls/xray-core/app/dns"
-	_ "github.com/xtls/xray-core/app/dns/fakedns"
+	// _ "github.com/xtls/xray-core/app/dns/fakedns"
 	_ "github.com/xtls/xray-core/app/log"
-	_ "github.com/xtls/xray-core/app/metrics"
-	_ "github.com/xtls/xray-core/app/policy"
-	_ "github.com/xtls/xray-core/app/reverse"
+	// _ "github.com/xtls/xray-core/app/metrics"
+	// _ "github.com/xtls/xray-core/app/policy"
+	// _ "github.com/xtls/xray-core/app/reverse"
 	_ "github.com/xtls/xray-core/app/router"
-	_ "github.com/xtls/xray-core/app/stats"
+	// _ "github.com/xtls/xray-core/app/stats"
 
 	// Fix dependency cycle caused by core import in internet package
 	_ "github.com/xtls/xray-core/transport/internet/tagged/taggedimpl"
 
 	// Developer preview features
-	_ "github.com/xtls/xray-core/app/observatory"
+	// _ "github.com/xtls/xray-core/app/observatory"
 
 	// Inbound and outbound proxies.
 	_ "github.com/xtls/xray-core/proxy/blackhole"


### PR DESCRIPTION
## Summary by Sourcery

Remove unused Xray packages and commented out unnecessary imports

Bug Fixes:
- Removed unnecessary package imports to reduce dependency bloat

Chores:
- Cleaned up unused and optional Xray core package imports