### PR TITLE
fix(url): fixed panicking issue on URL

### DIFF
--- a/xray/trojan_url.go
+++ b/xray/trojan_url.go
@@ -42,18 +42,31 @@ type TrojanURL struct {
 }
 
 func (v *TrojanURL) Raw() *url.URL {
+	if v == nil {
+		return nil
+	}
+
 	return v.Config.raw
 }
 
 func (v *TrojanURL) Opaque() string {
+	if v.Config == nil || v.Config.raw == nil {
+		return ""
+	}
 	return strings.TrimPrefix(v.Config.raw.String(), "trojan://")
 }
 
 func (v *TrojanURL) Host() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.Address
 }
 
 func (v *TrojanURL) Port() string {
+	if v.Config == nil {
+		return ""
+	}
 	return strconv.Itoa(v.Config.Port)
 }
 
@@ -62,6 +75,9 @@ func (v *TrojanURL) User() string {
 }
 
 func (v *TrojanURL) Password() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.Password
 }
 
@@ -70,6 +86,9 @@ func (v *TrojanURL) Protocol() string {
 }
 
 func (v *TrojanURL) Name() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.Remark
 }
 

--- a/xray/vless_url.go
+++ b/xray/vless_url.go
@@ -46,22 +46,37 @@ type VlessURL struct {
 }
 
 func (v *VlessURL) Raw() *url.URL {
+	if v.Config == nil {
+		return nil
+	}
 	return v.Config.raw
 }
 
 func (v *VlessURL) Opaque() string {
+	if v.Config == nil || v.Config.raw == nil {
+		return ""
+	}
 	return strings.TrimPrefix(v.Config.raw.String(), "vless://")
 }
 
 func (v *VlessURL) Host() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.Address
 }
 
 func (v *VlessURL) Port() string {
+	if v.Config == nil {
+		return ""
+	}
 	return strconv.Itoa(v.Config.Port)
 }
 
 func (v *VlessURL) User() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.UUID
 }
 
@@ -74,6 +89,9 @@ func (v *VlessURL) Protocol() string {
 }
 
 func (v *VlessURL) Name() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.Remark
 }
 

--- a/xray/vmess_url.go
+++ b/xray/vmess_url.go
@@ -49,18 +49,30 @@ type VmessURL struct {
 }
 
 func (v *VmessURL) Raw() *url.URL {
+	if v.Config == nil {
+		return nil
+	}
 	return v.Config.raw
 }
 
 func (v *VmessURL) Opaque() string {
+	if v.Config == nil || v.Config.raw == nil {
+		return ""
+	}
 	return strings.TrimPrefix(v.Config.raw.String(), "vmess://")
 }
 
 func (v *VmessURL) Host() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.Add
 }
 
 func (v *VmessURL) Port() string {
+	if v.Config == nil {
+		return ""
+	}
 	return strconv.Itoa(v.Config.Port.Value())
 }
 
@@ -69,6 +81,9 @@ func (v *VmessURL) Protocol() string {
 }
 
 func (v *VmessURL) User() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.ID
 }
 
@@ -77,6 +92,9 @@ func (v *VmessURL) Password() string {
 }
 
 func (v *VmessURL) Name() string {
+	if v.Config == nil {
+		return ""
+	}
 	return v.Config.PS
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent nil pointer dereferences in TrojanURL, VlessURL, and VmessURL methods by returning nil or empty values when Config or raw URL is absent.