### PR TITLE
fix: release mu before Instance.Close() in sweeper (follow-up to #79)

### DIFF
--- a/xray/xray.go
+++ b/xray/xray.go
@@ -86,15 +86,32 @@ func init() {
 func sweeper() {
 	for {
 		time.Sleep(sweepInterval)
+
+		// Collect expired URLs under lock, then release lock before closing
+		// to avoid blocking all map operations while Instance.Close() runs.
+		var expired []struct {
+			url  string
+			srv  *Server
+		}
 		mu.Lock()
 		now := time.Now()
 		for url, srv := range servers {
 			if !srv.DrainedAt.IsZero() && now.Sub(srv.DrainedAt) > drainTimeout {
-				srv.Instance.Close() //nolint: errcheck
-				delete(servers, url)
+				expired = append(expired, struct {
+					url  string
+					srv  *Server
+				}{url, srv})
 			}
 		}
 		mu.Unlock()
+
+		// Close instances outside the critical section.
+		for _, e := range expired {
+			e.srv.Instance.Close() //nolint: errcheck
+			mu.Lock()
+			delete(servers, e.url)
+			mu.Unlock()
+		}
 	}
 }
 


### PR DESCRIPTION
## Background
Follow-up to #79 — the previous fix held the mutex while calling `srv.Instance.Close()`, which could block all map operations if Close() is slow.

## Changes
Collect expired entries under lock, release lock, then close instances outside the critical section. The `delete()` call runs under lock again but is fast.

## Acceptance Criteria
- [x] No goroutine accumulation
- [x] Memory stays stable
- [x] `Close()` and `CloseAll()` work correctly
- [x] sweeper does not hold mu while calling slow `Instance.Close()`

## Summary by Sourcery

Introduce a background sweeper to drain and close xray server instances asynchronously after a timeout, avoiding holding the global mutex during potentially slow Close calls.

Bug Fixes:
- Prevent the sweeper from blocking all server map operations by releasing the mutex before invoking potentially slow Instance.Close calls.
- Ensure Close and CloseAll mark servers as draining and rely on the sweeper to close instances, reducing goroutine and memory leaks.

Enhancements:
- Track server drain state and support reviving draining servers on access to allow in-flight operations to complete cleanly before closure.