### PR TITLE
fix: update README example imports to use correct package paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,10 @@ package main
 import (
     "fmt"
     "github.com/cnlangzi/proxyclient"
-    // import v5 vmess/vless
-    _ "github.com/cnlangzi/proxyclient/v2ray"
+    // import v5 vmess/vless/trojan
+    _ "github.com/cnlangzi/proxyclient/xray"
+    // import ss
+    _ "github.com/cnlangzi/proxyclient/ss"
 )
 
 func main() {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ package main
 import (
     "fmt"
     "github.com/cnlangzi/proxyclient"
-    // import v5 vmess/vless/trojan
+    // import v5 vmess/vless/trojan/ssr (via xray)
     _ "github.com/cnlangzi/proxyclient/xray"
     // import ss
     _ "github.com/cnlangzi/proxyclient/ss"


### PR DESCRIPTION
Fix issue #88 - Incorrect example in README.md file

Changes:
- Replace non-existent 'proxyclient/v2ray' with 'proxyclient/xray'
- Add 'proxyclient/ss' import for Shadowsocks support  
- Align comments with actual import paths